### PR TITLE
Integrate LockManager into Engine, fix reconciliation, update to .NET 10

### DIFF
--- a/Ajuna.SAGE.Core.Test/Ajuna.SAGE.Core.Test.csproj
+++ b/Ajuna.SAGE.Core.Test/Ajuna.SAGE.Core.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Ajuna.SAGE.Core.Test/EngineBuilderTest.cs
+++ b/Ajuna.SAGE.Core.Test/EngineBuilderTest.cs
@@ -28,7 +28,7 @@ namespace Ajuna.SAGE.Core.Test
             var identifier = new ActionIdentifier(ActionType.TypeA, ActionSubType.TypeX);
             var rules = new ActionRule(ActionRuleType.MinAsset, ActionRuleOp.GreaterEqual, 1);
 
-            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m) =>
+            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m, l) =>
             {
                 var asset = w.First();
                 asset.Score += 10;
@@ -69,14 +69,14 @@ namespace Ajuna.SAGE.Core.Test
             var rules1 = new ActionRule(ActionRuleType.MinAsset, ActionRuleOp.GreaterEqual, 1);
             var rules2 = new ActionRule(ActionRuleType.MaxAsset, ActionRuleOp.LesserEqual, 5);
 
-            TransitionFunction<ActionRule> function1 = (e, r, f, w, h, b, c, m) =>
+            TransitionFunction<ActionRule> function1 = (e, r, f, w, h, b, c, m, l) =>
             {
                 var asset = w.First();
                 asset.Score += 10;
                 return new List<IAsset> { asset };
             };
 
-            TransitionFunction<ActionRule> function2 = (e, r, f, w, h, b, c, m) =>
+            TransitionFunction<ActionRule> function2 = (e, r, f, w, h, b, c, m, l) =>
             {
                 var asset = w.First();
                 asset.Score += 20;

--- a/Ajuna.SAGE.Core.Test/EngineTest.cs
+++ b/Ajuna.SAGE.Core.Test/EngineTest.cs
@@ -39,7 +39,7 @@ namespace Ajuna.SAGE.Core.Test
 
             var rules = new ActionRule(ActionRuleType.MinAsset, ActionRuleOp.GreaterEqual, 1);
 
-            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m) =>
+            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m, l) =>
             {
                 var asset = w.First();
                 asset.Score += 10;
@@ -82,7 +82,7 @@ namespace Ajuna.SAGE.Core.Test
             var identifier = new ActionIdentifier(ActionType.TypeA, ActionSubType.TypeX);
             var rules = new ActionRule(ActionRuleType.MinAsset, ActionRuleOp.GreaterEqual, 1);
 
-            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m) => w.Select(a => a);
+            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m, l) => w.Select(a => a);
 
             _engine.AddTransition(identifier, [rules], default, function);
 
@@ -134,7 +134,7 @@ namespace Ajuna.SAGE.Core.Test
             var identifier = new ActionIdentifier(ActionType.TypeA, ActionSubType.TypeX);
             var rule = new ActionRule(ActionRuleType.MinAsset, ActionRuleOp.GreaterEqual, 2);
 
-            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m) => w.Select(a => a);
+            TransitionFunction<ActionRule> function = (e, r, f, w, h, b, c, m, l) => w.Select(a => a);
 
             var blockchainInfoProvider = new Mock<IBlockchainInfoProvider>();
             blockchainInfoProvider.Setup(b => b.GenerateRandomHash()).Returns(new byte[] { 0x00 });

--- a/Ajuna.SAGE.Core/Ajuna.SAGE.Core.csproj
+++ b/Ajuna.SAGE.Core/Ajuna.SAGE.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<!-- NuGet Package Informationen -->
 		<PackageId>Ajuna.SAGE.Core</PackageId>

--- a/Ajuna.SAGE.Core/Ajuna.SAGE.Core.csproj
+++ b/Ajuna.SAGE.Core/Ajuna.SAGE.Core.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<!-- NuGet Package Informationen -->
 		<PackageId>Ajuna.SAGE.Core</PackageId>
-		<Version>0.0.7</Version>
+		<Version>0.1.0</Version>
 		<Company>BloGa Tech AG</Company>
 		<Authors>Cedric Decoster</Authors>
 		<Description>Substrate Asset Game Engine (reference implementation)</Description>

--- a/Ajuna.SAGE.Core/Engine.cs
+++ b/Ajuna.SAGE.Core/Engine.cs
@@ -1,4 +1,4 @@
-﻿using Ajuna.SAGE.Core.Manager;
+using Ajuna.SAGE.Core.Manager;
 using Ajuna.SAGE.Core.Model;
 using System;
 using System.Collections.Generic;
@@ -17,7 +17,8 @@ namespace Ajuna.SAGE.Core
         byte[] randomHash,
         uint blockNumber,
         object? config,
-        IBalanceManager assetBalances)
+        IBalanceManager assetBalances,
+        ILock lockManager)
         where TRules : ITransitionRule;
 
     public class Engine<TIdentifier, TRules>
@@ -40,6 +41,9 @@ namespace Ajuna.SAGE.Core
         private readonly BalanceManager _assetBalanceManager;
         public IBalanceManager AssetBalanceManager => _assetBalanceManager;
 
+        private readonly LockManager _lockManager;
+        public ILock LockManager => _lockManager;
+
         // only for testing
         public uint? AssetBalance(ulong id) => _assetBalanceManager.AssetBalance(id);
 
@@ -56,6 +60,7 @@ namespace Ajuna.SAGE.Core
             _accountManager = new AccountManager();
             _assetManager = new AssetManager();
             _assetBalanceManager = new BalanceManager();
+            _lockManager = new LockManager();
         }
 
         /// <summary>
@@ -105,10 +110,10 @@ namespace Ajuna.SAGE.Core
                 throw new NotSupportedException("Trying to transition duplicates.");
             }
 
-            // lockable check
-            if (inAssets.Any(p => p.IsLockable))
+            // lock check: reject assets that are lockable AND currently locked
+            if (inAssets.Any(p => p.IsLockable && _lockManager.IsLocked(p.Id) == true))
             {
-                throw new NotSupportedException("Trying to transition lockable.");
+                throw new NotSupportedException("Trying to transition a locked asset.");
             }
 
             if (!_transitions.TryGetValue(identifier, out (TRules[] rules, ITransitionFee? fee, TransitionFunction<TRules> function) tuple))
@@ -135,7 +140,7 @@ namespace Ajuna.SAGE.Core
             }
 
             // execute the transition function
-            IEnumerable<IAsset> functionResult = function(executor, rules, fee, inAssets, randomHash, blockNumber, config, _assetBalanceManager);
+            IEnumerable<IAsset> functionResult = function(executor, rules, fee, inAssets, randomHash, blockNumber, config, _assetBalanceManager, _lockManager);
 
             outAssets = functionResult != null ? functionResult.ToArray() : Array.Empty<IAsset>();
 
@@ -156,15 +161,16 @@ namespace Ajuna.SAGE.Core
             var updateIds = new List<uint>();
             var deleteIds = new List<uint>();
             var createIds = new List<uint>();
+
+            // find all updated and deleted ids
             if (inputIds != null)
             {
                 foreach (var inputId in inputIds)
                 {
                     if (outputIds != null && outputIds.Contains(inputId))
                     {
-
                         updateIds.Add(inputId);
-                     }
+                    }
                     else
                     {
                         deleteIds.Add(inputId);
@@ -172,6 +178,7 @@ namespace Ajuna.SAGE.Core
                 }
             }
 
+            // find all created ids
             if (outputs != null)
             {
                 foreach (var output in outputIds)
@@ -183,22 +190,19 @@ namespace Ajuna.SAGE.Core
                 }
             }
 
-            if (outputs != null)
+            // handle all created assets in the asset manager
+            foreach (var id in createIds)
             {
-                foreach (var id in createIds)
-                {
-                    _assetManager.Create(outputs.First(p => p.Id == id));
-                }
+                _assetManager.Create(outputs.First(p => p.Id == id));
             }
 
-            if (inputs != null)
+            // handle all updated assets in the asset manager
+            foreach (var id in updateIds)
             {
-                foreach (var id in updateIds)
-                {
-                    _assetManager.Update(inputs.First(p => p.Id == id));
-                }
+                _assetManager.Update(outputs.First(p => p.Id == id));
             }
 
+            // handle all deleted assets in the asset manager
             foreach (var id in deleteIds)
             {
                 _assetManager.Delete(id);

--- a/Ajuna.SAGE.Generic/Ajuna.SAGE.Generic.csproj
+++ b/Ajuna.SAGE.Generic/Ajuna.SAGE.Generic.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<!-- NuGet Package Informationen -->
 		<PackageId>Ajuna.SAGE.Generic</PackageId>
-		<Version>0.0.5</Version>
+		<Version>0.1.0</Version>
 		<Company>BloGa Tech AG</Company>
 		<Authors>Cedric Decoster</Authors>
 		<Description>Substrate Asset Game Engine (generics)</Description>

--- a/Ajuna.SAGE.Generic/Ajuna.SAGE.Generic.csproj
+++ b/Ajuna.SAGE.Generic/Ajuna.SAGE.Generic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<!-- NuGet Package Informationen -->
 		<PackageId>Ajuna.SAGE.Generic</PackageId>


### PR DESCRIPTION
## Summary

- **Integrate LockManager into Engine**: The `LockManager` was defined but never instantiated or used by the engine. This PR adds it as a first-class member alongside `AccountManager`, `AssetManager`, and `BalanceManager`.
- **Fix lock check semantics**: `IsLockable` now correctly means "this asset supports locking" (capability flag), while `LockManager.IsLocked(id)` tracks the actual lock state. The engine rejects transitions on assets that are lockable AND currently locked.
- **Fix reconciliation bug**: `Update` operations in `Transition()` now source from `outputs` (modified assets returned by the transition function) instead of `inputs` (original unmodified assets). This ensures modifications made by transition functions are correctly persisted.
- **Pass LockManager to transitions**: The `TransitionFunction` delegate now receives `ILock lockManager` as its 9th parameter, allowing transitions to call `Lock(id)` and `Unlock(id)`.
- **Update to .NET 10**: Target frameworks updated from `netstandard2.1;net6.0;net8.0` to `netstandard2.1;net10.0`.

## Test plan
- [x] All 51 existing SAGE Core tests pass on .NET 10
- [ ] Verify FullHouseFury game still compiles with updated delegate signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)