### PR TITLE
Update CI workflows for .NET 10

### DIFF
--- a/.github/workflows/publish_core.yml
+++ b/.github/workflows/publish_core.yml
@@ -8,36 +8,27 @@ jobs:
   build:
     name: build & test & publish
     runs-on: ubuntu-latest
-        
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       ##
       # Setup
-      # Setup multiple .NET versions so we can build against all referenced .NET versions.
+      # Setup .NET versions for multi-target build (netstandard2.1 + net10.0).
       ##
-      - name: Setup .NET Core 2.1.x
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET 10.0.x
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 2.1.x
-     
-      - name: Setup .NET 6.0.x
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
 
-      - name: Setup .NET 8.0.x
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 8.0.x
-      
       ##
       # Dependencies
       # Restore the project and its dependencies.
       ##
       - name: Install dependencies
         run: dotnet restore
-      
+
       # Test
       - name: Test
         run: |

--- a/.github/workflows/publish_generic.yml
+++ b/.github/workflows/publish_generic.yml
@@ -8,36 +8,27 @@ jobs:
   build:
     name: build & test & publish
     runs-on: ubuntu-latest
-        
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       ##
       # Setup
-      # Setup multiple .NET versions so we can build against all referenced .NET versions.
+      # Setup .NET versions for multi-target build (netstandard2.1 + net10.0).
       ##
-      - name: Setup .NET Core 2.1.x
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET 10.0.x
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 2.1.x
-     
-      - name: Setup .NET 6.0.x
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
 
-      - name: Setup .NET 8.0.x
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 8.0.x
-      
       ##
       # Dependencies
       # Restore the project and its dependencies.
       ##
       - name: Install dependencies
         run: dotnet restore
-      
+
       ##
       # Publish
       ##


### PR DESCRIPTION
## Summary

- Replace .NET 2.1/6.0/8.0 setup steps with single .NET 10.0 preview setup
- Bump `actions/checkout` from v2 to v4
- Bump `actions/setup-dotnet` from v1 to v4

The target frameworks were updated to `netstandard2.1;net10.0` in #2 but the CI workflows still referenced the old .NET versions, which would cause build failures.

## Test plan
- [ ] CI pipeline runs successfully with .NET 10 preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)