### PR TITLE
Add ISnapshotable interface and Engine.Snapshot/Restore facade

### DIFF
--- a/Ajuna.SAGE.Core.Test/SnapshotTest.cs
+++ b/Ajuna.SAGE.Core.Test/SnapshotTest.cs
@@ -1,0 +1,296 @@
+using Ajuna.SAGE.Core.Manager;
+using Ajuna.SAGE.Core.Model;
+using System.IO;
+
+namespace Ajuna.SAGE.Core.Test
+{
+    /// <summary>
+    /// Round-trip tests for the new ISnapshotable surface on each manager
+    /// and BlockchainInfoProvider, plus the Engine.Snapshot/Restore facade.
+    /// </summary>
+    [TestFixture]
+    public class SnapshotTest
+    {
+        // ── AccountManager ────────────────────────────────────────────
+
+        [Test]
+        public void AccountManager_Snapshot_RoundTrip_PreservesAccountsAndIds()
+        {
+            var src = new AccountManager();
+            var id1 = src.Create();
+            var id2 = src.Create();
+            src.Account(id1)!.Balance.Deposit(123);
+            src.Account(id2)!.Balance.Deposit(456);
+
+            var snapshot = src.Snapshot();
+
+            var dst = new AccountManager();
+            dst.Restore(snapshot);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(dst.EngineId, Is.EqualTo(src.EngineId));
+                Assert.That(dst.Account(id1), Is.Not.Null);
+                Assert.That(dst.Account(id1)!.Balance.Value, Is.EqualTo(123));
+                Assert.That(dst.Account(id2)!.Balance.Value, Is.EqualTo(456));
+                // Next-id counter must continue from where the source left off.
+                var idAfter = dst.Create();
+                Assert.That(idAfter, Is.GreaterThan(id2));
+            });
+        }
+
+        [Test]
+        public void AccountManager_Restore_BadVersion_Throws()
+        {
+            var dst = new AccountManager();
+            var bad = new byte[] { 99 }; // wrong version byte
+            Assert.Throws<InvalidDataException>(() => dst.Restore(bad));
+        }
+
+        // ── AssetManager ──────────────────────────────────────────────
+
+        [Test]
+        public void AssetManager_Snapshot_RoundTrip_PreservesAssets()
+        {
+            var src = new AssetManager();
+            var a1 = new Asset(0, 1, 7, 100, 200, new byte[] { 0xAA, 0xBB }) { IsLockable = true };
+            var a2 = new Asset(0, 2, 7, 50, 0, new byte[] { 0x01 }) { IsLockable = false };
+            src.Create(a1);
+            src.Create(a2);
+
+            var snapshot = src.Snapshot();
+
+            var dst = new AssetManager();
+            dst.Restore(snapshot);
+
+            var restored1 = dst.Read(a1.Id);
+            var restored2 = dst.Read(a2.Id);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(restored1, Is.Not.Null);
+                Assert.That(restored1!.OwnerId, Is.EqualTo(1));
+                Assert.That(restored1.CollectionId, Is.EqualTo(7));
+                Assert.That(restored1.Score, Is.EqualTo(100));
+                Assert.That(restored1.Genesis, Is.EqualTo(200));
+                Assert.That(restored1.IsLockable, Is.True);
+                Assert.That(restored1.Data, Is.EqualTo(new byte[] { 0xAA, 0xBB }));
+                Assert.That(restored2!.IsLockable, Is.False);
+                // Next-id continues from the source's high-water mark.
+                var newAsset = new Asset(0, 1, 1, 0, 0, new byte[1]);
+                var newId = dst.Create(newAsset);
+                Assert.That(newId, Is.GreaterThan(a2.Id));
+            });
+        }
+
+        [Test]
+        public void AssetManager_AllAssets_EnumeratesEverything()
+        {
+            var mgr = new AssetManager();
+            mgr.Create(new Asset(0, 1, 1, 0, 0, new byte[1]));
+            mgr.Create(new Asset(0, 2, 1, 0, 0, new byte[1]));
+            mgr.Create(new Asset(0, 3, 1, 0, 0, new byte[1]));
+
+            var all = mgr.AllAssets().ToList();
+            Assert.That(all, Has.Count.EqualTo(3));
+        }
+
+        // ── BalanceManager ────────────────────────────────────────────
+
+        [Test]
+        public void BalanceManager_Snapshot_RoundTrip_PreservesBalances()
+        {
+            var src = new BalanceManager();
+            src.Deposit(1, 1000);
+            src.Deposit(42, 250);
+            src.Deposit(1000000, 999_999);
+
+            var snapshot = src.Snapshot();
+
+            var dst = new BalanceManager();
+            dst.Restore(snapshot);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(dst.AssetBalance(1), Is.EqualTo(1000));
+                Assert.That(dst.AssetBalance(42), Is.EqualTo(250));
+                Assert.That(dst.AssetBalance(1000000), Is.EqualTo(999_999));
+                Assert.That(dst.AssetBalance(99), Is.Null);
+            });
+        }
+
+        // ── LockManager ───────────────────────────────────────────────
+
+        [Test]
+        public void LockManager_Snapshot_RoundTrip_PreservesLockStates()
+        {
+            var src = new LockManager();
+            src.Lock(1);
+            src.Lock(2);
+            src.Lock(3);
+            src.Unlock(2); // 2 ends in unlocked state, but tracked
+
+            var snapshot = src.Snapshot();
+
+            var dst = new LockManager();
+            dst.Restore(snapshot);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(dst.IsLocked(1), Is.True);
+                Assert.That(dst.IsLocked(2), Is.False);
+                Assert.That(dst.IsLocked(3), Is.True);
+                Assert.That(dst.IsLocked(99), Is.Null);
+            });
+        }
+
+        // ── MarketManager ─────────────────────────────────────────────
+
+        [Test]
+        public void MarketManager_Snapshot_RoundTrip_PreservesListings()
+        {
+            var src = new MarketManager();
+            src.List(10, 500);
+            src.List(20, 1000);
+            src.List(30, 2500);
+
+            var snapshot = src.Snapshot();
+
+            var dst = new MarketManager();
+            dst.Restore(snapshot);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(dst.GetPrice(10), Is.EqualTo(500));
+                Assert.That(dst.GetPrice(20), Is.EqualTo(1000));
+                Assert.That(dst.GetPrice(30), Is.EqualTo(2500));
+                Assert.That(dst.IsListed(99), Is.False);
+            });
+        }
+
+        // ── BlockchainInfoProvider ────────────────────────────────────
+
+        [Test]
+        public void BlockchainInfoProvider_Snapshot_RoundTrip_PreservesBlockAndRng()
+        {
+            var src = new BlockchainInfoProvider(seed: 12345);
+            src.IncrementBlockNumber();
+            src.IncrementBlockNumber();
+            src.IncrementBlockNumber();
+            src.GenerateRandomHash();
+            src.GenerateRandomHash();
+
+            var snapshot = src.Snapshot();
+
+            var dst = new BlockchainInfoProvider(seed: 99999); // wrong seed — restore must overwrite
+            dst.Restore(snapshot);
+
+            // Block number preserved
+            Assert.That(dst.CurrentBlockNumber, Is.EqualTo(src.CurrentBlockNumber));
+
+            // RNG continuation: next hash from src and from dst must match.
+            var srcNext = src.GenerateRandomHash();
+            var dstNext = dst.GenerateRandomHash();
+            Assert.That(dstNext, Is.EqualTo(srcNext), "RNG should resume in the same position after restore");
+        }
+
+        // ── Engine facade ─────────────────────────────────────────────
+
+        private static Engine<ActionIdentifier, ActionRule> NewEngine()
+        {
+            var bcp = new BlockchainInfoProvider(seed: 42);
+            return new Engine<ActionIdentifier, ActionRule>(bcp, (p, r, a, b, c, m, s) => true);
+        }
+
+        [Test]
+        public void Engine_Snapshot_FullRoundTrip_PreservesAllState()
+        {
+            var src = NewEngine();
+
+            // Populate every manager
+            var aliceId = src.AccountManager.Create();
+            var bobId = src.AccountManager.Create();
+            src.AccountManager.Account(aliceId)!.Balance.Deposit(5000);
+            src.AccountManager.Account(bobId)!.Balance.Deposit(3000);
+
+            var asset1 = new Asset(0, aliceId, 1, 100, 0, new byte[] { 0x10 }) { IsLockable = true };
+            var asset2 = new Asset(0, bobId, 1, 200, 0, new byte[] { 0x20 });
+            src.AssetManager.Create(asset1);
+            src.AssetManager.Create(asset2);
+
+            src.AssetBalanceManager.Deposit(1, 750); // treasury keyed by collection id
+            src.LockManager.Lock(asset1.Id);
+            src.MarketManager.List(asset2.Id, 999);
+
+            // Advance the chain a few times
+            src.BlockchainInfoProvider.IncrementBlockNumber();
+            src.BlockchainInfoProvider.IncrementBlockNumber();
+
+            var snapshot = src.Snapshot();
+
+            // Restore into a brand new engine (different RNG seed to prove it gets overwritten)
+            var dst = new Engine<ActionIdentifier, ActionRule>(
+                new BlockchainInfoProvider(seed: 7),
+                (p, r, a, b, c, m, s) => true);
+            dst.Restore(snapshot);
+
+            Assert.Multiple(() =>
+            {
+                // Accounts
+                Assert.That(dst.AccountManager.Account(aliceId)!.Balance.Value, Is.EqualTo(5000));
+                Assert.That(dst.AccountManager.Account(bobId)!.Balance.Value, Is.EqualTo(3000));
+
+                // Assets
+                var r1 = dst.AssetManager.Read(asset1.Id);
+                var r2 = dst.AssetManager.Read(asset2.Id);
+                Assert.That(r1, Is.Not.Null);
+                Assert.That(r1!.OwnerId, Is.EqualTo(aliceId));
+                Assert.That(r1.IsLockable, Is.True);
+                Assert.That(r1.Data![0], Is.EqualTo(0x10));
+                Assert.That(r2!.OwnerId, Is.EqualTo(bobId));
+
+                // Treasury / balances
+                Assert.That(dst.AssetBalanceManager.AssetBalance(1), Is.EqualTo(750));
+
+                // Locks
+                Assert.That(dst.LockManager.IsLocked(asset1.Id), Is.True);
+
+                // Market
+                Assert.That(dst.MarketManager.GetPrice(asset2.Id), Is.EqualTo(999));
+
+                // Block number
+                Assert.That(dst.BlockchainInfoProvider.CurrentBlockNumber,
+                    Is.EqualTo(src.BlockchainInfoProvider.CurrentBlockNumber));
+            });
+        }
+
+        [Test]
+        public void Engine_Restore_VersionMismatch_Throws()
+        {
+            var dst = NewEngine();
+            var bad = new byte[] { 99 }; // wrong envelope version
+            Assert.Throws<InvalidDataException>(() => dst.Restore(bad));
+        }
+
+        [Test]
+        public void Engine_Restore_RoundTripsAllAssetsViaAllAssets()
+        {
+            var src = NewEngine();
+            var ownerId = src.AccountManager.Create();
+            for (int i = 0; i < 5; i++)
+            {
+                src.AssetManager.Create(new Asset(0, ownerId, 1, (uint)i, 0, new byte[] { (byte)i }));
+            }
+
+            var snapshot = src.Snapshot();
+
+            var dst = new Engine<ActionIdentifier, ActionRule>(
+                new BlockchainInfoProvider(seed: 0),
+                (p, r, a, b, c, m, s) => true);
+            dst.Restore(snapshot);
+
+            var all = dst.AssetManager.AllAssets().ToList();
+            Assert.That(all, Has.Count.EqualTo(5));
+        }
+    }
+}

--- a/Ajuna.SAGE.Core/BlockchainInfoProvider.cs
+++ b/Ajuna.SAGE.Core/BlockchainInfoProvider.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.IO;
 
 namespace Ajuna.SAGE.Core
 {
@@ -10,12 +11,18 @@ namespace Ajuna.SAGE.Core
         void IncrementBlockNumber();
     }
 
-    public class BlockchainInfoProvider : IBlockchainInfoProvider
+    public class BlockchainInfoProvider : IBlockchainInfoProvider, ISnapshotable
     {
+        // Snapshot format version for BlockchainInfoProvider.
+        private const byte SNAPSHOT_VERSION = 1;
+
+        private int _seed;
+        private uint _hashCount;
         private Random _random;
 
         public BlockchainInfoProvider(int seed)
         {
+            _seed = seed;
             _random = new Random(seed);
         }
 
@@ -23,6 +30,7 @@ namespace Ajuna.SAGE.Core
         {
             byte[] randomHash = new byte[32];
             _random.NextBytes(randomHash);
+            _hashCount++;
             return randomHash;
         }
 
@@ -31,6 +39,43 @@ namespace Ajuna.SAGE.Core
         public void IncrementBlockNumber()
         {
             CurrentBlockNumber++;
+        }
+
+        /// <inheritdoc/>
+        public byte[] Snapshot()
+        {
+            using var ms = new MemoryStream();
+            using var w = new BinaryWriter(ms);
+            w.Write(SNAPSHOT_VERSION);
+            w.Write(_seed);
+            w.Write(_hashCount);
+            w.Write(CurrentBlockNumber);
+            return ms.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Restore(byte[] snapshot)
+        {
+            if (snapshot == null) throw new InvalidDataException("BlockchainInfoProvider snapshot is null");
+            using var ms = new MemoryStream(snapshot);
+            using var r = new BinaryReader(ms);
+            var version = r.ReadByte();
+            if (version != SNAPSHOT_VERSION)
+                throw new InvalidDataException($"BlockchainInfoProvider snapshot version {version} not supported (expected {SNAPSHOT_VERSION})");
+
+            _seed = r.ReadInt32();
+            _hashCount = r.ReadUInt32();
+            CurrentBlockNumber = r.ReadUInt32();
+
+            // Recreate the RNG from the original seed and re-advance it
+            // by _hashCount calls so that subsequent GenerateRandomHash()
+            // calls produce the same sequence as before the snapshot.
+            _random = new Random(_seed);
+            var scratch = new byte[32];
+            for (uint i = 0; i < _hashCount; i++)
+            {
+                _random.NextBytes(scratch);
+            }
         }
     }
 }

--- a/Ajuna.SAGE.Core/Engine.cs
+++ b/Ajuna.SAGE.Core/Engine.cs
@@ -2,6 +2,7 @@ using Ajuna.SAGE.Core.Manager;
 using Ajuna.SAGE.Core.Model;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -214,5 +215,91 @@ namespace Ajuna.SAGE.Core
             }
         }
 
+        // ─── Snapshot / Restore facade ────────────────────────────────────
+        //
+        // Engine.Snapshot() and Engine.Restore() let consumers persist the
+        // entire engine state via a single opaque byte payload. Each
+        // manager (and the BlockchainInfoProvider) implements ISnapshotable;
+        // the engine simply concatenates each component's snapshot inside a
+        // versioned envelope so future format additions don't break old
+        // snapshots.
+        //
+        // Transition rules and the verify function are NOT serialized — they
+        // are wired in at engine construction by the consumer's builder, so
+        // a typical restore flow looks like:
+        //
+        //     var engine = AvatarEngineBuilder.Build(blockchainInfo);
+        //     engine.Restore(File.ReadAllBytes("gamestate.bin"));
+        //
+        // The consumer is responsible for using the SAME builder both before
+        // saving and after loading.
+
+        private const byte ENGINE_SNAPSHOT_VERSION = 1;
+
+        /// <summary>
+        /// Serializes the entire engine state (all five managers + the
+        /// blockchain info provider) into a single versioned byte payload
+        /// that can later be replayed via <see cref="Restore"/>.
+        /// </summary>
+        public byte[] Snapshot()
+        {
+            using var ms = new MemoryStream();
+            using var w = new BinaryWriter(ms);
+
+            w.Write(ENGINE_SNAPSHOT_VERSION);
+
+            WriteSection(w, _accountManager.Snapshot());
+            WriteSection(w, _assetManager.Snapshot());
+            WriteSection(w, _assetBalanceManager.Snapshot());
+            WriteSection(w, _lockManager.Snapshot());
+            WriteSection(w, _marketManager.Snapshot());
+            WriteSection(w, RequireSnapshotable(_blockchainInfo, nameof(_blockchainInfo)).Snapshot());
+
+            return ms.ToArray();
+        }
+
+        /// <summary>
+        /// Replaces the entire engine state with the contents of a snapshot
+        /// previously produced by <see cref="Snapshot"/>. Existing in-memory
+        /// state is discarded before the snapshot is applied. Throws
+        /// <see cref="InvalidDataException"/> if the payload is malformed
+        /// or its envelope version is incompatible.
+        /// </summary>
+        public void Restore(byte[] snapshot)
+        {
+            if (snapshot == null) throw new InvalidDataException("Engine snapshot is null");
+            using var ms = new MemoryStream(snapshot);
+            using var r = new BinaryReader(ms);
+
+            var version = r.ReadByte();
+            if (version != ENGINE_SNAPSHOT_VERSION)
+                throw new InvalidDataException($"Engine snapshot version {version} not supported (expected {ENGINE_SNAPSHOT_VERSION})");
+
+            _accountManager.Restore(ReadSection(r));
+            _assetManager.Restore(ReadSection(r));
+            _assetBalanceManager.Restore(ReadSection(r));
+            _lockManager.Restore(ReadSection(r));
+            _marketManager.Restore(ReadSection(r));
+            RequireSnapshotable(_blockchainInfo, nameof(_blockchainInfo)).Restore(ReadSection(r));
+        }
+
+        private static void WriteSection(BinaryWriter w, byte[] payload)
+        {
+            w.Write(payload.Length);
+            w.Write(payload);
+        }
+
+        private static byte[] ReadSection(BinaryReader r)
+        {
+            int length = r.ReadInt32();
+            return r.ReadBytes(length);
+        }
+
+        private static ISnapshotable RequireSnapshotable(object component, string name)
+        {
+            if (component is ISnapshotable s) return s;
+            throw new InvalidOperationException(
+                $"{name} ({component.GetType().FullName}) does not implement ISnapshotable; cannot snapshot/restore the engine.");
+        }
     }
 }

--- a/Ajuna.SAGE.Core/ISnapshotable.cs
+++ b/Ajuna.SAGE.Core/ISnapshotable.cs
@@ -1,0 +1,35 @@
+namespace Ajuna.SAGE.Core
+{
+    /// <summary>
+    /// Implemented by every component that holds mutable runtime state
+    /// (managers + BlockchainInfoProvider). <see cref="Snapshot"/> returns
+    /// an opaque byte payload that <see cref="Restore"/> can later replay
+    /// to reconstruct the component's exact state.
+    ///
+    /// Used by <c>Engine.Snapshot</c> / <c>Engine.Restore</c> to persist
+    /// and reload the entire engine state without consumers needing to
+    /// reach into manager internals.
+    /// </summary>
+    public interface ISnapshotable
+    {
+        /// <summary>
+        /// Serialize the component's full mutable state into a byte
+        /// payload. The payload is opaque to callers — the same component
+        /// type that produced it must be the one to <see cref="Restore"/>
+        /// it.
+        /// </summary>
+        byte[] Snapshot();
+
+        /// <summary>
+        /// Replace the component's current state with the contents of a
+        /// snapshot previously produced by <see cref="Snapshot"/>. The
+        /// component is reset before applying the snapshot, so any
+        /// pre-existing in-memory state is discarded.
+        /// </summary>
+        /// <exception cref="System.IO.InvalidDataException">
+        /// If the payload is malformed, truncated, or was produced by an
+        /// incompatible component / format version.
+        /// </exception>
+        void Restore(byte[] snapshot);
+    }
+}

--- a/Ajuna.SAGE.Core/Manager/AccountManager.cs
+++ b/Ajuna.SAGE.Core/Manager/AccountManager.cs
@@ -1,5 +1,6 @@
 using Ajuna.SAGE.Core.Model;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Ajuna.SAGE.Core.Manager
 {
@@ -31,13 +32,16 @@ namespace Ajuna.SAGE.Core.Manager
         uint EngineId { get; }
     }
 
-    public class AccountManager : IAccountManager
+    public class AccountManager : IAccountManager, ISnapshotable
     {
+        // Snapshot format version for AccountManager. Bump on layout change.
+        private const byte SNAPSHOT_VERSION = 1;
+
         private uint _nextId;
 
         private readonly Dictionary<uint, IAccount> _data = new Dictionary<uint, IAccount>();
 
-        private readonly uint _engineId;
+        private uint _engineId;
 
         /// <inheritdoc/>
         public uint EngineId => _engineId;
@@ -77,6 +81,45 @@ namespace Ajuna.SAGE.Core.Manager
                 return null;
             }
             return account;
+        }
+
+        /// <inheritdoc/>
+        public byte[] Snapshot()
+        {
+            using var ms = new MemoryStream();
+            using var w = new BinaryWriter(ms);
+            w.Write(SNAPSHOT_VERSION);
+            w.Write(_nextId);
+            w.Write(_engineId);
+            w.Write(_data.Count);
+            foreach (var kv in _data)
+            {
+                w.Write(kv.Value.Id);
+                w.Write(kv.Value.Balance.Value);
+            }
+            return ms.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Restore(byte[] snapshot)
+        {
+            if (snapshot == null) throw new InvalidDataException("AccountManager snapshot is null");
+            using var ms = new MemoryStream(snapshot);
+            using var r = new BinaryReader(ms);
+            var version = r.ReadByte();
+            if (version != SNAPSHOT_VERSION)
+                throw new InvalidDataException($"AccountManager snapshot version {version} not supported (expected {SNAPSHOT_VERSION})");
+
+            _data.Clear();
+            _nextId = r.ReadUInt32();
+            _engineId = r.ReadUInt32();
+            int count = r.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                uint id = r.ReadUInt32();
+                uint balance = r.ReadUInt32();
+                _data[id] = new Account(id, balance);
+            }
         }
     }
 }

--- a/Ajuna.SAGE.Core/Manager/AssetManager.cs
+++ b/Ajuna.SAGE.Core/Manager/AssetManager.cs
@@ -1,5 +1,6 @@
 using Ajuna.SAGE.Core.Model;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Ajuna.SAGE.Core.Manager
@@ -40,10 +41,19 @@ namespace Ajuna.SAGE.Core.Manager
         /// Get all assets owned by the given account.
         /// </summary>
         IEnumerable<IAsset> AssetOf(IAccount account);
+
+        /// <summary>
+        /// Enumerate every asset currently in the manager regardless of
+        /// owner. Order is not guaranteed.
+        /// </summary>
+        IEnumerable<IAsset> AllAssets();
     }
 
-    public class AssetManager : IAssetManager
+    public class AssetManager : IAssetManager, ISnapshotable
     {
+        // Snapshot format version for AssetManager. Bump on layout change.
+        private const byte SNAPSHOT_VERSION = 1;
+
         private uint _nextId;
 
         private readonly Dictionary<uint, IAsset> _data;
@@ -101,6 +111,73 @@ namespace Ajuna.SAGE.Core.Manager
         public IEnumerable<IAsset> AssetOf(IAccount account)
         {
             return _data.Values.Where(p => p.OwnedBy(account)).ToList();
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<IAsset> AllAssets() => _data.Values.ToList();
+
+        /// <inheritdoc/>
+        public byte[] Snapshot()
+        {
+            using var ms = new MemoryStream();
+            using var w = new BinaryWriter(ms);
+            w.Write(SNAPSHOT_VERSION);
+            w.Write(_nextId);
+            w.Write(_data.Count);
+            foreach (var asset in _data.Values)
+            {
+                w.Write(asset.Id);
+                w.Write(asset.OwnerId);
+                w.Write(asset.CollectionId);
+                w.Write(asset.Score);
+                w.Write(asset.Genesis);
+                w.Write(asset.IsLockable);
+                w.Write(asset.MatchTypeSize);
+                if (asset.Data == null)
+                {
+                    w.Write(-1);
+                }
+                else
+                {
+                    w.Write(asset.Data.Length);
+                    w.Write(asset.Data);
+                }
+            }
+            return ms.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Restore(byte[] snapshot)
+        {
+            if (snapshot == null) throw new InvalidDataException("AssetManager snapshot is null");
+            using var ms = new MemoryStream(snapshot);
+            using var r = new BinaryReader(ms);
+            var version = r.ReadByte();
+            if (version != SNAPSHOT_VERSION)
+                throw new InvalidDataException($"AssetManager snapshot version {version} not supported (expected {SNAPSHOT_VERSION})");
+
+            _data.Clear();
+            _nextId = r.ReadUInt32();
+            int count = r.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                uint id = r.ReadUInt32();
+                uint ownerId = r.ReadUInt32();
+                byte collectionId = r.ReadByte();
+                uint score = r.ReadUInt32();
+                uint genesis = r.ReadUInt32();
+                bool isLockable = r.ReadBoolean();
+                byte matchTypeSize = r.ReadByte();
+                int dataLen = r.ReadInt32();
+                byte[]? data = dataLen < 0 ? null : r.ReadBytes(dataLen);
+
+                var asset = new Asset(id, ownerId, collectionId, score, genesis, data)
+                {
+                    IsLockable = isLockable,
+                    MatchTypeSize = matchTypeSize,
+                };
+                _data[id] = asset;
+            }
         }
     }
 }

--- a/Ajuna.SAGE.Core/Manager/BalanceManager.cs
+++ b/Ajuna.SAGE.Core/Manager/BalanceManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Ajuna.SAGE.Core.Manager
@@ -44,8 +45,11 @@ namespace Ajuna.SAGE.Core.Manager
         uint? AssetBalance(ulong id);
     }
 
-    public class BalanceManager : IBalanceManager
+    public class BalanceManager : IBalanceManager, ISnapshotable
     {
+        // Snapshot format version for BalanceManager. Bump on layout change.
+        private const byte SNAPSHOT_VERSION = 1;
+
         private readonly Dictionary<ulong, uint> _data = new Dictionary<ulong, uint>();
 
         /// <inheritdoc/>
@@ -88,5 +92,40 @@ namespace Ajuna.SAGE.Core.Manager
 
         /// <inheritdoc/>
         public uint? AssetBalance(ulong id) => _data.TryGetValue(id, out uint balance) ? balance : (uint?)null;
+
+        /// <inheritdoc/>
+        public byte[] Snapshot()
+        {
+            using var ms = new MemoryStream();
+            using var w = new BinaryWriter(ms);
+            w.Write(SNAPSHOT_VERSION);
+            w.Write(_data.Count);
+            foreach (var kv in _data)
+            {
+                w.Write(kv.Key);
+                w.Write(kv.Value);
+            }
+            return ms.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Restore(byte[] snapshot)
+        {
+            if (snapshot == null) throw new InvalidDataException("BalanceManager snapshot is null");
+            using var ms = new MemoryStream(snapshot);
+            using var r = new BinaryReader(ms);
+            var version = r.ReadByte();
+            if (version != SNAPSHOT_VERSION)
+                throw new InvalidDataException($"BalanceManager snapshot version {version} not supported (expected {SNAPSHOT_VERSION})");
+
+            _data.Clear();
+            int count = r.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                ulong key = r.ReadUInt64();
+                uint value = r.ReadUInt32();
+                _data[key] = value;
+            }
+        }
     }
 }

--- a/Ajuna.SAGE.Core/Manager/LockManager.cs
+++ b/Ajuna.SAGE.Core/Manager/LockManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 
 namespace Ajuna.SAGE.Core.Manager
 {
@@ -30,10 +31,19 @@ namespace Ajuna.SAGE.Core.Manager
         /// Unlock an asset. Returns false if not currently locked.
         /// </summary>
         bool Unlock(ulong id);
+
+        /// <summary>
+        /// Inspect the current lock state for an asset without mutating it.
+        /// Returns null if the asset has never been locked or unlocked.
+        /// </summary>
+        bool? IsLocked(ulong id);
     }
 
-    public class LockManager : ILock
+    public class LockManager : ILock, ISnapshotable
     {
+        // Snapshot format version for LockManager. Bump on layout change.
+        private const byte SNAPSHOT_VERSION = 1;
+
         private readonly Dictionary<ulong, bool> _data = new Dictionary<ulong, bool>();
 
         /// <inheritdoc/>
@@ -77,5 +87,40 @@ namespace Ajuna.SAGE.Core.Manager
         /// Returns null if the asset has never been locked/unlocked.
         /// </summary>
         public bool? IsLocked(ulong id) => _data.TryGetValue(id, out bool state) ? state : (bool?)null;
+
+        /// <inheritdoc/>
+        public byte[] Snapshot()
+        {
+            using var ms = new MemoryStream();
+            using var w = new BinaryWriter(ms);
+            w.Write(SNAPSHOT_VERSION);
+            w.Write(_data.Count);
+            foreach (var kv in _data)
+            {
+                w.Write(kv.Key);
+                w.Write(kv.Value);
+            }
+            return ms.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Restore(byte[] snapshot)
+        {
+            if (snapshot == null) throw new InvalidDataException("LockManager snapshot is null");
+            using var ms = new MemoryStream(snapshot);
+            using var r = new BinaryReader(ms);
+            var version = r.ReadByte();
+            if (version != SNAPSHOT_VERSION)
+                throw new InvalidDataException($"LockManager snapshot version {version} not supported (expected {SNAPSHOT_VERSION})");
+
+            _data.Clear();
+            int count = r.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                ulong key = r.ReadUInt64();
+                bool value = r.ReadBoolean();
+                _data[key] = value;
+            }
+        }
     }
 }

--- a/Ajuna.SAGE.Core/Manager/MarketManager.cs
+++ b/Ajuna.SAGE.Core/Manager/MarketManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Ajuna.SAGE.Core.Manager
@@ -35,8 +36,11 @@ namespace Ajuna.SAGE.Core.Manager
         IEnumerable<(uint assetId, uint price)> GetAllListings();
     }
 
-    public class MarketManager : IMarket
+    public class MarketManager : IMarket, ISnapshotable
     {
+        // Snapshot format version for MarketManager. Bump on layout change.
+        private const byte SNAPSHOT_VERSION = 1;
+
         private readonly Dictionary<uint, uint> _listings = new Dictionary<uint, uint>();
 
         public bool List(uint assetId, uint price)
@@ -68,6 +72,41 @@ namespace Ajuna.SAGE.Core.Manager
         public IEnumerable<(uint assetId, uint price)> GetAllListings()
         {
             return _listings.Select(kv => (kv.Key, kv.Value));
+        }
+
+        /// <inheritdoc/>
+        public byte[] Snapshot()
+        {
+            using var ms = new MemoryStream();
+            using var w = new BinaryWriter(ms);
+            w.Write(SNAPSHOT_VERSION);
+            w.Write(_listings.Count);
+            foreach (var kv in _listings)
+            {
+                w.Write(kv.Key);
+                w.Write(kv.Value);
+            }
+            return ms.ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void Restore(byte[] snapshot)
+        {
+            if (snapshot == null) throw new InvalidDataException("MarketManager snapshot is null");
+            using var ms = new MemoryStream(snapshot);
+            using var r = new BinaryReader(ms);
+            var version = r.ReadByte();
+            if (version != SNAPSHOT_VERSION)
+                throw new InvalidDataException($"MarketManager snapshot version {version} not supported (expected {SNAPSHOT_VERSION})");
+
+            _listings.Clear();
+            int count = r.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                uint key = r.ReadUInt32();
+                uint value = r.ReadUInt32();
+                _listings[key] = value;
+            }
         }
     }
 }


### PR DESCRIPTION
Introduce a new ISnapshotable interface implemented by every manager (Account, Asset, Balance, Lock, Market) and BlockchainInfoProvider so each component can serialize its full mutable state to an opaque byte payload and later restore from one. Engine.Snapshot()/Restore() compose these into a single versioned envelope, letting consumers persist and reload the entire engine state without reaching into manager internals.

Two small interface additions support this: ILock.IsLocked exposes the inspector that LockManager already had as a public method, and IAssetManager.AllAssets enumerates the full asset store without walking accounts (needed by consumers that rebuild server-side indices on load).

The snapshot format is binary (BinaryWriter) with per-component version bytes plus a top-level envelope version, so the layout can evolve without breaking existing snapshots. RNG continuity for BlockchainInfoProvider is preserved by storing the original seed plus the count of GenerateRandomHash calls and re-advancing the Random instance during restore.

New SnapshotTest fixture (11 tests) covers per-manager round-trips, the Engine.Snapshot/Restore facade across all managers, version mismatch handling, and explicit RNG-continuity verification. 127/127 SAGE Core tests pass; downstream Ajuna.SAGE.Avatars consumers continue to pass 172/172 tests with no code changes required.